### PR TITLE
Add basic chat UI for Android client

### DIFF
--- a/clients/KurisuAssistant/app/build.gradle.kts
+++ b/clients/KurisuAssistant/app/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.recyclerview)
+    implementation(libs.androidx.lifecycle.viewmodel.ktx)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/clients/KurisuAssistant/app/build.gradle.kts
+++ b/clients/KurisuAssistant/app/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.recyclerview)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/clients/KurisuAssistant/app/src/main/AndroidManifest.xml
+++ b/clients/KurisuAssistant/app/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
         <service android:name=".RecordingService" android:exported="false"/>
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/Agent.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/Agent.kt
@@ -3,6 +3,8 @@ package com.kurisuassistant.android
 import android.media.AudioTrack
 import android.util.Log
 import androidx.collection.MutableIntList
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import com.kurisuassistant.android.utils.Util
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.Channel
@@ -15,6 +17,14 @@ import org.json.JSONObject
 import java.util.concurrent.TimeUnit
 
 class Agent(val player: AudioTrack) {
+    private val _connected = MutableLiveData(false)
+    val connected: LiveData<Boolean> get() = _connected
+        _connected.postValue(false)
+
+                _connected.postValue(true)
+                _connected.postValue(false)
+                _connected.postValue(false)
+        _connected.postValue(false)
     private val modelName = "gemma3:12b-it-qat-tool"
     private val TAG = "Agent"
     private var client: OkHttpClient

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/Agent.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/Agent.kt
@@ -15,7 +15,7 @@ import org.json.JSONObject
 import java.util.concurrent.TimeUnit
 
 class Agent(val player: AudioTrack) {
-    private val modelName = "qwen2.5:3b"
+    private val modelName = "gemma3:12b-it-qat-tool"
     private val TAG = "Agent"
     private var client: OkHttpClient
     private var webSocket: WebSocket? = null

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatAdapter.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatAdapter.kt
@@ -1,0 +1,57 @@
+package com.kurisuassistant.android
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.kurisuassistant.android.model.ChatMessage
+
+/**
+ * RecyclerView adapter displaying chat messages.
+ */
+class ChatAdapter(private var messages: List<ChatMessage>) :
+    RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    companion object {
+        private const val USER = 0
+        private const val ASSISTANT = 1
+    }
+
+    fun update(newMessages: List<ChatMessage>) {
+        messages = newMessages
+        notifyDataSetChanged()
+    }
+
+    override fun getItemViewType(position: Int): Int = if (messages[position].isUser) USER else ASSISTANT
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return if (viewType == USER) {
+            val view = inflater.inflate(R.layout.item_user_message, parent, false)
+            UserHolder(view)
+        } else {
+            val view = inflater.inflate(R.layout.item_assistant_message, parent, false)
+            AssistantHolder(view)
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        val msg = messages[position]
+        when (holder) {
+            is UserHolder -> holder.text.text = msg.text
+            is AssistantHolder -> holder.text.text = msg.text
+        }
+    }
+
+    override fun getItemCount(): Int = messages.size
+
+    class UserHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val text: TextView = view.findViewById(R.id.message_text)
+    }
+
+    class AssistantHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val text: TextView = view.findViewById(R.id.message_text)
+    }
+}
+

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatRepository.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatRepository.kt
@@ -3,6 +3,7 @@ package com.kurisuassistant.android
 import android.media.AudioAttributes
 import android.media.AudioFormat
 import android.media.AudioTrack
+import com.kurisuassistant.android.model.ChatMessage
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineScope

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatRepository.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatRepository.kt
@@ -41,6 +41,13 @@ object ChatRepository {
     private val agent by lazy { Agent(player) }
     private val scope = CoroutineScope(Dispatchers.IO)
 
+    val connected: LiveData<Boolean>
+        get() = agent.connected
+
+    fun init() {
+        agent
+    }
+
     /**
      * Send a user text message to the LLM and stream the assistant reply.
      */

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatRepository.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatRepository.kt
@@ -1,0 +1,89 @@
+package com.kurisuassistant.android
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioTrack
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+
+/**
+ * Singleton repository that manages chat messages and communicates with [Agent].
+ */
+object ChatRepository {
+    private val _messages = MutableLiveData<MutableList<ChatMessage>>(mutableListOf())
+    val messages: LiveData<MutableList<ChatMessage>> = _messages
+
+    private val player: AudioTrack by lazy {
+        AudioTrack.Builder()
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_MEDIA)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build()
+            )
+            .setAudioFormat(
+                AudioFormat.Builder()
+                    .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                    .setSampleRate(32_000)
+                    .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                    .build()
+            )
+            .setTransferMode(AudioTrack.MODE_STREAM)
+            .setBufferSizeInBytes(1024)
+            .build().apply { play() }
+    }
+
+    private val agent by lazy { Agent(player) }
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    /**
+     * Send a user text message to the LLM and stream the assistant reply.
+     */
+    fun sendMessage(text: String) {
+        val list = _messages.value ?: mutableListOf()
+        list.add(ChatMessage(text, true))
+        _messages.value = list
+
+        scope.launch {
+            val channel: Channel<String> = agent.chat(text)
+            val assistant = ChatMessage("", false)
+            list.add(assistant)
+            val idx = list.lastIndex
+            _messages.postValue(ArrayList(list))
+            for (chunk in channel) {
+                list[idx] = ChatMessage(list[idx].text + chunk, false)
+                _messages.postValue(ArrayList(list))
+            }
+        }
+    }
+
+    /**
+     * Add a user message originating from voice input. Returns the index of the
+     * assistant message that should be updated with chunks.
+     */
+    fun addVoiceUserMessage(text: String): Int {
+        val list = _messages.value ?: mutableListOf()
+        list.add(ChatMessage(text, true))
+        val assistant = ChatMessage("", false)
+        list.add(assistant)
+        val idx = list.lastIndex
+        _messages.postValue(ArrayList(list))
+        return idx
+    }
+
+    /**
+     * Append a chunk of assistant text to a message at [index]. Used when the
+     * service streams replies via its own [Agent].
+     */
+    fun appendAssistantChunk(chunk: String, index: Int) {
+        val list = _messages.value ?: return
+        if (index >= list.size) return
+        val current = list[index]
+        list[index] = ChatMessage(current.text + chunk, false)
+        _messages.postValue(ArrayList(list))
+    }
+}

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatViewModel.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatViewModel.kt
@@ -1,0 +1,66 @@
+package com.kurisuassistant.android
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioTrack
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kurisuassistant.android.model.ChatMessage
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel holding the chat conversation state.
+ */
+class ChatViewModel : ViewModel() {
+
+    private val _messages = MutableLiveData<MutableList<ChatMessage>>(mutableListOf())
+    val messages: LiveData<MutableList<ChatMessage>> = _messages
+
+    private val agent: Agent
+
+    init {
+        val player = AudioTrack.Builder()
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_MEDIA)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build()
+            )
+            .setAudioFormat(
+                AudioFormat.Builder()
+                    .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                    .setSampleRate(32_000)
+                    .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                    .build()
+            )
+            .setTransferMode(AudioTrack.MODE_STREAM)
+            .setBufferSizeInBytes(1024)
+            .build()
+        player.play()
+        agent = Agent(player)
+    }
+
+    /**
+     * Send a user message to the LLM via [Agent] and update the UI state.
+     */
+    fun sendMessage(text: String) {
+        val list = _messages.value ?: mutableListOf()
+        list.add(ChatMessage(text, true))
+        _messages.value = list
+
+        viewModelScope.launch {
+            val channel = agent.chat(text)
+            val assistant = ChatMessage("", false)
+            list.add(assistant)
+            var idx = list.lastIndex
+            _messages.postValue(ArrayList(list))
+            for (chunk in channel) {
+                list[idx] = ChatMessage(list[idx].text + chunk, false)
+                _messages.postValue(ArrayList(list))
+            }
+        }
+    }
+}
+

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatViewModel.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatViewModel.kt
@@ -1,66 +1,15 @@
 package com.kurisuassistant.android
 
-import android.media.AudioAttributes
-import android.media.AudioFormat
-import android.media.AudioTrack
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.kurisuassistant.android.model.ChatMessage
-import kotlinx.coroutines.launch
 
 /**
- * ViewModel holding the chat conversation state.
+ * ViewModel exposing chat messages from [ChatRepository].
  */
 class ChatViewModel : ViewModel() {
+    val messages: LiveData<MutableList<ChatMessage>> = ChatRepository.messages
 
-    private val _messages = MutableLiveData<MutableList<ChatMessage>>(mutableListOf())
-    val messages: LiveData<MutableList<ChatMessage>> = _messages
-
-    private val agent: Agent
-
-    init {
-        val player = AudioTrack.Builder()
-            .setAudioAttributes(
-                AudioAttributes.Builder()
-                    .setUsage(AudioAttributes.USAGE_MEDIA)
-                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-                    .build()
-            )
-            .setAudioFormat(
-                AudioFormat.Builder()
-                    .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
-                    .setSampleRate(32_000)
-                    .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
-                    .build()
-            )
-            .setTransferMode(AudioTrack.MODE_STREAM)
-            .setBufferSizeInBytes(1024)
-            .build()
-        player.play()
-        agent = Agent(player)
-    }
-
-    /**
-     * Send a user message to the LLM via [Agent] and update the UI state.
-     */
     fun sendMessage(text: String) {
-        val list = _messages.value ?: mutableListOf()
-        list.add(ChatMessage(text, true))
-        _messages.value = list
-
-        viewModelScope.launch {
-            val channel = agent.chat(text)
-            val assistant = ChatMessage("", false)
-            list.add(assistant)
-            var idx = list.lastIndex
-            _messages.postValue(ArrayList(list))
-            for (chunk in channel) {
-                list[idx] = ChatMessage(list[idx].text + chunk, false)
-                _messages.postValue(ArrayList(list))
-            }
-        }
+        ChatRepository.sendMessage(text)
     }
 }
-

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatViewModel.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatViewModel.kt
@@ -9,6 +9,11 @@ import com.kurisuassistant.android.model.ChatMessage
  */
 class ChatViewModel : ViewModel() {
     val messages: LiveData<MutableList<ChatMessage>> = ChatRepository.messages
+    val connected: LiveData<Boolean> = ChatRepository.connected
+
+    init {
+        ChatRepository.init()
+    }
 
     fun sendMessage(text: String) {
         ChatRepository.sendMessage(text)

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatViewModel.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatViewModel.kt
@@ -2,6 +2,7 @@ package com.kurisuassistant.android
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import com.kurisuassistant.android.model.ChatMessage
 
 /**
  * ViewModel exposing chat messages from [ChatRepository].

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/MainActivity.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/MainActivity.kt
@@ -3,17 +3,18 @@ package com.kurisuassistant.android
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
-import android.widget.TextView
+import android.widget.EditText
+import android.widget.ImageButton
 import android.widget.Toast
+import androidx.activity.viewModels
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.recyclerview.widget.RecyclerView
 import com.kurisuassistant.android.silerovad.SileroVadOnnxModel
 import com.kurisuassistant.android.utils.Util
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
 
 class MainActivity : AppCompatActivity() {
     companion object {
@@ -27,6 +28,9 @@ class MainActivity : AppCompatActivity() {
     val MIN_SILENCE_DURATION_MS: Int = 100
     val SPEECH_PAD_MS: Int = 30
     lateinit var vadModel: SileroVadOnnxModel
+    private val viewModel: ChatViewModel by viewModels()
+    private lateinit var adapter: ChatAdapter
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -37,6 +41,24 @@ class MainActivity : AppCompatActivity() {
             insets
         }
         Util.checkPermissions(this)
+
+        val recyclerView = findViewById<RecyclerView>(R.id.recyclerView)
+        adapter = ChatAdapter(viewModel.messages.value ?: emptyList())
+        recyclerView.adapter = adapter
+
+        val editText = findViewById<EditText>(R.id.editTextMessage)
+        val sendButton = findViewById<ImageButton>(R.id.buttonSend)
+
+        viewModel.messages.observe(this) { adapter.update(it) }
+
+        sendButton.setOnClickListener {
+            val text = editText.text.toString().trim()
+            if (text.isNotEmpty()) {
+                viewModel.sendMessage(text)
+                editText.text.clear()
+            }
+        }
+
         startRecordingService()
     }
 

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/MainActivity.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/MainActivity.kt
@@ -3,8 +3,10 @@ package com.kurisuassistant.android
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import android.view.View
 import android.widget.EditText
 import android.widget.ImageButton
+import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.activity.enableEdgeToEdge
@@ -12,6 +14,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.kurisuassistant.android.silerovad.SileroVadOnnxModel
 import com.kurisuassistant.android.utils.Util
@@ -45,11 +48,18 @@ class MainActivity : AppCompatActivity() {
         val recyclerView = findViewById<RecyclerView>(R.id.recyclerView)
         adapter = ChatAdapter(viewModel.messages.value ?: emptyList())
         recyclerView.adapter = adapter
+        recyclerView.layoutManager = LinearLayoutManager(this)
 
         val editText = findViewById<EditText>(R.id.editTextMessage)
         val sendButton = findViewById<ImageButton>(R.id.buttonSend)
+        val recordButton = findViewById<ImageButton>(R.id.buttonRecord)
+        val recordIndicator = findViewById<TextView>(R.id.recordIndicator)
+        var isRecording = false
 
-        viewModel.messages.observe(this) { adapter.update(it) }
+        viewModel.messages.observe(this) {
+            adapter.update(it)
+            recyclerView.scrollToPosition(adapter.itemCount - 1)
+        }
 
         sendButton.setOnClickListener {
             val text = editText.text.toString().trim()
@@ -59,13 +69,29 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-        startRecordingService()
+        recordButton.setOnClickListener {
+            if (isRecording) {
+                stopRecordingService()
+                recordIndicator.visibility = View.GONE
+            } else {
+                startRecordingService()
+                recordIndicator.visibility = View.VISIBLE
+            }
+            isRecording = !isRecording
+        }
     }
 
     private fun startRecordingService() {
         val intent = Intent(this, RecordingService::class.java)
-        ContextCompat.startForegroundService(this, intent)  // start service :contentReference[oaicite:9]{index=9}
-        Log.d(TAG, "RecordingService spawned")             // debug log :contentReference[oaicite:10]{index=10}
-        Toast.makeText(this, "RecordingService spawned", Toast.LENGTH_SHORT).show()
+        ContextCompat.startForegroundService(this, intent)
+        Log.d(TAG, "RecordingService spawned")
+        Toast.makeText(this, "Recording started", Toast.LENGTH_SHORT).show()
+    }
+
+    private fun stopRecordingService() {
+        val intent = Intent(this, RecordingService::class.java)
+        stopService(intent)
+        Log.d(TAG, "RecordingService stopped")
+        Toast.makeText(this, "Recording stopped", Toast.LENGTH_SHORT).show()
     }
 }

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/MainActivity.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/MainActivity.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import android.view.View
 import android.widget.EditText
 import android.widget.ImageButton
+import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.viewModels
@@ -45,11 +46,18 @@ class MainActivity : AppCompatActivity() {
         val sendButton = findViewById<ImageButton>(R.id.buttonSend)
         val recordButton = findViewById<ImageButton>(R.id.buttonRecord)
         val recordIndicator = findViewById<TextView>(R.id.recordIndicator)
+        val connectionIndicator = findViewById<ImageView>(R.id.connectionIndicator)
         var isRecording = false
 
         viewModel.messages.observe(this) {
             adapter.update(it)
             recyclerView.scrollToPosition(adapter.itemCount - 1)
+        }
+
+        viewModel.connected.observe(this) { connected ->
+            val res = if (connected) android.R.drawable.presence_online
+            else android.R.drawable.presence_offline
+            connectionIndicator.setImageResource(res)
         }
 
         sendButton.setOnClickListener {

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/MainActivity.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/MainActivity.kt
@@ -9,11 +9,8 @@ import android.widget.ImageButton
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.viewModels
-import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.kurisuassistant.android.silerovad.SileroVadOnnxModel
@@ -36,13 +33,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
         setContentView(R.layout.activity_main)
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
-            insets
-        }
         Util.checkPermissions(this)
 
         val recyclerView = findViewById<RecyclerView>(R.id.recyclerView)

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/RecordingService.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/RecordingService.kt
@@ -26,6 +26,7 @@ import com.kurisuassistant.android.silerovad.SileroVadDetector
 import com.kurisuassistant.android.silerovad.SileroVadOnnxModel
 import com.kurisuassistant.android.utils.CircularQueue
 import com.kurisuassistant.android.utils.Util
+import com.kurisuassistant.android.ChatRepository
 import okhttp3.MediaType.Companion.toMediaType
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -227,9 +228,11 @@ class RecordingService : Service() {
                         if (isInteracting)
                         {
                             Log.d(TAG, "User: $text")
+                            val idx = ChatRepository.addVoiceUserMessage(text)
                             val chatStream = agent.chat(text)
                             for (content in chatStream)
                             {
+                                ChatRepository.appendAssistantChunk(content, idx)
                                 Log.d(TAG, "Assistant: $content")
                             }
                             // audio replies are streamed via WebSocket and played automatically

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/model/ChatMessage.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/model/ChatMessage.kt
@@ -1,0 +1,10 @@
+package com.kurisuassistant.android.model
+
+/**
+ * Represents a single chat message either from the user or the assistant.
+ */
+data class ChatMessage(
+    val text: String,
+    val isUser: Boolean
+)
+

--- a/clients/KurisuAssistant/app/src/main/res/drawable/bg_assistant_message.xml
+++ b/clients/KurisuAssistant/app/src/main/res/drawable/bg_assistant_message.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/assistantBubbleColor" />
+    <corners android:radius="16dp" />
+</shape>

--- a/clients/KurisuAssistant/app/src/main/res/drawable/bg_user_message.xml
+++ b/clients/KurisuAssistant/app/src/main/res/drawable/bg_user_message.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/userBubbleColor" />
+    <corners android:radius="16dp" />
+</shape>

--- a/clients/KurisuAssistant/app/src/main/res/layout/activity_main.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/activity_main.xml
@@ -17,6 +17,16 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
 
+    <ImageView
+        android:id="@+id/connectionIndicator"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_margin="8dp"
+        android:contentDescription="Connection status"
+        android:src="@android:drawable/presence_offline"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
     <LinearLayout
         android:id="@+id/input_container"
         android:layout_width="0dp"

--- a/clients/KurisuAssistant/app/src/main/res/layout/activity_main.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/activity_main.xml
@@ -7,14 +7,37 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <TextView
-        android:id="@+id/main_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/input_container"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"/>
 
+    <LinearLayout
+        android:id="@+id/input_container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <EditText
+            android:id="@+id/editTextMessage"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="Type a message"/>
+
+        <ImageButton
+            android:id="@+id/buttonSend"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@android:drawable/ic_menu_send"
+            android:contentDescription="Send"/>
+    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/clients/KurisuAssistant/app/src/main/res/layout/activity_main.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/activity_main.xml
@@ -39,5 +39,22 @@
             android:layout_height="wrap_content"
             android:src="@android:drawable/ic_menu_send"
             android:contentDescription="Send"/>
+
+        <ImageButton
+            android:id="@+id/buttonRecord"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@android:drawable/ic_btn_speak_now"
+            android:contentDescription="Record voice"/>
     </LinearLayout>
+
+    <TextView
+        android:id="@+id/recordIndicator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Recording..."
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@id/input_container"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/clients/KurisuAssistant/app/src/main/res/layout/activity_main.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,7 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/white"
     tools:context=".MainActivity">
 
     <androidx.recyclerview.widget.RecyclerView
@@ -38,6 +39,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:src="@android:drawable/ic_menu_send"
+            android:tint="@color/primaryBlue"
             android:contentDescription="Send"/>
 
         <ImageButton
@@ -45,6 +47,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:src="@android:drawable/ic_btn_speak_now"
+            android:tint="@color/primaryBlue"
             android:contentDescription="Record voice"/>
     </LinearLayout>
 
@@ -53,6 +56,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Recording..."
+        android:textColor="@color/primaryBlue"
         android:visibility="gone"
         app:layout_constraintBottom_toTopOf="@id/input_container"
         app:layout_constraintStart_toStartOf="parent"

--- a/clients/KurisuAssistant/app/src/main/res/layout/activity_main.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/activity_main.xml
@@ -32,7 +32,9 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:hint="Type a message"/>
+            android:hint="Type a message"
+            android:textColor="@android:color/black"
+            android:textColorHint="@android:color/darker_gray"/>
 
         <ImageButton
             android:id="@+id/buttonSend"

--- a/clients/KurisuAssistant/app/src/main/res/layout/item_assistant_message.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/item_assistant_message.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="start"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/message_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_assistant_message"
+        android:padding="8dp"
+        android:textColor="@android:color/black"
+        android:textSize="16sp" />
+</LinearLayout>

--- a/clients/KurisuAssistant/app/src/main/res/layout/item_user_message.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/item_user_message.xml
@@ -11,6 +11,6 @@
         android:layout_height="wrap_content"
         android:background="@drawable/bg_user_message"
         android:padding="8dp"
-        android:textColor="@android:color/black"
+        android:textColor="@android:color/white"
         android:textSize="16sp" />
 </LinearLayout>

--- a/clients/KurisuAssistant/app/src/main/res/layout/item_user_message.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/item_user_message.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="end"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/message_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_user_message"
+        android:padding="8dp"
+        android:textColor="@android:color/black"
+        android:textSize="16sp" />
+</LinearLayout>

--- a/clients/KurisuAssistant/app/src/main/res/values-night/themes.xml
+++ b/clients/KurisuAssistant/app/src/main/res/values-night/themes.xml
@@ -1,7 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Base.Theme.KurisuAssistant" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Customize your dark theme here. -->
-        <!-- <item name="colorPrimary">@color/my_dark_primary</item> -->
+        <item name="colorPrimary">@color/primaryBlue</item>
+        <item name="colorOnPrimary">@android:color/white</item>
     </style>
 </resources>

--- a/clients/KurisuAssistant/app/src/main/res/values/colors.xml
+++ b/clients/KurisuAssistant/app/src/main/res/values/colors.xml
@@ -2,6 +2,7 @@
 <resources>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="userBubbleColor">#DCF8C6</color>
-    <color name="assistantBubbleColor">#FFFFFF</color>
+    <color name="primaryBlue">#0084FF</color>
+    <color name="userBubbleColor">@color/primaryBlue</color>
+    <color name="assistantBubbleColor">#E5E5EA</color>
 </resources>

--- a/clients/KurisuAssistant/app/src/main/res/values/colors.xml
+++ b/clients/KurisuAssistant/app/src/main/res/values/colors.xml
@@ -2,4 +2,6 @@
 <resources>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="userBubbleColor">#DCF8C6</color>
+    <color name="assistantBubbleColor">#FFFFFF</color>
 </resources>

--- a/clients/KurisuAssistant/app/src/main/res/values/themes.xml
+++ b/clients/KurisuAssistant/app/src/main/res/values/themes.xml
@@ -1,8 +1,10 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Base.Theme.KurisuAssistant" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Customize your light theme here. -->
-        <!-- <item name="colorPrimary">@color/my_light_primary</item> -->
+    <style name="Base.Theme.KurisuAssistant" parent="Theme.Material3.Light.NoActionBar">
+        <item name="colorPrimary">@color/primaryBlue</item>
+        <item name="colorOnPrimary">@android:color/white</item>
+        <item name="colorSurface">@color/white</item>
+        <item name="colorOnSurface">@android:color/black</item>
     </style>
 
     <style name="Theme.KurisuAssistant" parent="Base.Theme.KurisuAssistant" />

--- a/clients/KurisuAssistant/gradle/libs.versions.toml
+++ b/clients/KurisuAssistant/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ activity = "1.10.1"
 constraintlayout = "2.2.1"
 media3CommonKtx = "1.7.1"
 recyclerview = "1.3.2"
+lifecycle = "2.8.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -23,6 +24,7 @@ androidx-activity = { group = "androidx.activity", name = "activity", version.re
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-media3-common-ktx = { group = "androidx.media3", name = "media3-common-ktx", version.ref = "media3CommonKtx" }
 androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "recyclerview" }
+androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/clients/KurisuAssistant/gradle/libs.versions.toml
+++ b/clients/KurisuAssistant/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ material = "1.12.0"
 activity = "1.10.1"
 constraintlayout = "2.2.1"
 media3CommonKtx = "1.7.1"
+recyclerview = "1.3.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -21,6 +22,7 @@ material = { group = "com.google.android.material", name = "material", version.r
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-media3-common-ktx = { group = "androidx.media3", name = "media3-common-ktx", version.ref = "media3CommonKtx" }
+androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "recyclerview" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/core/helpers/llm.py
+++ b/core/helpers/llm.py
@@ -42,25 +42,26 @@ class LLM:
                                 print(self.history[-1])
                         is_final = False
                     
-                    if chunk.message.content != "":
+                    if is_final:
                         full_response += chunk.message.content
                         #full_response = re.sub(r'<think>.*?</think>', '', full_response, flags=re.DOTALL)
                         partial_response += chunk.message.content
 
-                    delimiter_idx = max([partial_response.rfind(delimiter) for delimiter in self.delimiters])
-                    if delimiter_idx != -1:
-                        response_buffer += partial_response[:delimiter_idx+1]
-                        partial_response = partial_response[delimiter_idx+1:]
-                    elif chunk['done']:
-                        response_buffer += partial_response
-                        partial_response = ""
-                    
-                    if is_final and (len(response_buffer) > 20 or chunk['done']):
-                        json_response['message']['content'] = response_buffer
-                        yield json_response
-                        response_buffer = ""
+                        delimiter_idx = max([partial_response.rfind(delimiter) for delimiter in self.delimiters])
+                        if delimiter_idx != -1:
+                            response_buffer += partial_response[:delimiter_idx+1]
+                            partial_response = partial_response[delimiter_idx+1:]
+                        elif chunk['done']:
+                            response_buffer += partial_response
+                            partial_response = ""
+                        
+                        if (len(response_buffer) > 20 or chunk['done']):
+                            json_response['message']['content'] = response_buffer
+                            yield json_response
+                            response_buffer = ""
                         
             self.history.append({"role": "assistant", "content": full_response})
+            print(self.history[-1])
             
         return stream_generator()
         


### PR DESCRIPTION
## Summary
- add RecyclerView and message layouts for a chat screen
- implement `ChatAdapter`, `ChatMessage` and `ChatViewModel`
- hook the ViewModel and adapter into `MainActivity`
- enable RecyclerView dependency in Gradle

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6847f082b0c08321ac23e54bcbd476f9