### PR TITLE
Fix ucrop dependency resolution

### DIFF
--- a/clients/KurisuAssistant/settings.gradle.kts
+++ b/clients/KurisuAssistant/settings.gradle.kts
@@ -7,6 +7,7 @@ pluginManagement {
                 includeGroupByRegex("androidx.*")
             }
         }
+        maven("https://jitpack.io")
         mavenCentral()
         gradlePluginPortal()
     }
@@ -15,6 +16,7 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
+        maven("https://jitpack.io")
         mavenCentral()
     }
 }


### PR DESCRIPTION
## Summary
- add JitPack repository to Gradle settings to resolve ucrop

## Testing
- `bash ./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a77d9d0b08321942b377ab7fbfa9f