### PR TITLE
Add typing/speaking indicators on Android

### DIFF
--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatRepository.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatRepository.kt
@@ -43,6 +43,10 @@ object ChatRepository {
 
     val connected: LiveData<Boolean>
         get() = agent.connected
+    val typing: LiveData<Boolean>
+        get() = agent.typing
+    val speaking: LiveData<Boolean>
+        get() = agent.speaking
 
     fun init() {
         agent

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatViewModel.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatViewModel.kt
@@ -10,6 +10,8 @@ import com.kurisuassistant.android.model.ChatMessage
 class ChatViewModel : ViewModel() {
     val messages: LiveData<MutableList<ChatMessage>> = ChatRepository.messages
     val connected: LiveData<Boolean> = ChatRepository.connected
+    val typing: LiveData<Boolean> = ChatRepository.typing
+    val speaking: LiveData<Boolean> = ChatRepository.speaking
 
     init {
         ChatRepository.init()

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/MainActivity.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/MainActivity.kt
@@ -36,6 +36,7 @@ class MainActivity : AppCompatActivity() {
     lateinit var vadModel: SileroVadOnnxModel
     private val viewModel: ChatViewModel by viewModels()
     private lateinit var adapter: ChatAdapter
+    private var responding: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -54,8 +55,6 @@ class MainActivity : AppCompatActivity() {
         val sendButton = findViewById<ImageButton>(R.id.buttonSend)
         val recordButton = findViewById<ImageButton>(R.id.buttonRecord)
         val recordIndicator = findViewById<TextView>(R.id.recordIndicator)
-        val typingIndicator = findViewById<TextView>(R.id.typingIndicator)
-        val speakingIndicator = findViewById<TextView>(R.id.speakingIndicator)
         val connectionIndicator = findViewById<ImageView>(R.id.connectionIndicator)
         var isRecording = false
 
@@ -71,11 +70,11 @@ class MainActivity : AppCompatActivity() {
         }
 
         viewModel.typing.observe(this) { typing ->
-            typingIndicator.visibility = if (typing) View.VISIBLE else View.GONE
+            updateResponding(typing || (viewModel.speaking.value == true))
         }
 
         viewModel.speaking.observe(this) { speaking ->
-            speakingIndicator.visibility = if (speaking) View.VISIBLE else View.GONE
+            updateResponding(speaking || (viewModel.typing.value == true))
         }
 
         sendButton.setOnClickListener {
@@ -96,6 +95,12 @@ class MainActivity : AppCompatActivity() {
             }
             isRecording = !isRecording
         }
+    }
+
+    private fun updateResponding(value: Boolean) {
+        if (responding == value) return
+        responding = value
+        adapter.setResponding(value)
     }
 
     private fun startRecordingService() {

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/MainActivity.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/MainActivity.kt
@@ -54,6 +54,8 @@ class MainActivity : AppCompatActivity() {
         val sendButton = findViewById<ImageButton>(R.id.buttonSend)
         val recordButton = findViewById<ImageButton>(R.id.buttonRecord)
         val recordIndicator = findViewById<TextView>(R.id.recordIndicator)
+        val typingIndicator = findViewById<TextView>(R.id.typingIndicator)
+        val speakingIndicator = findViewById<TextView>(R.id.speakingIndicator)
         val connectionIndicator = findViewById<ImageView>(R.id.connectionIndicator)
         var isRecording = false
 
@@ -66,6 +68,14 @@ class MainActivity : AppCompatActivity() {
             val res = if (connected) android.R.drawable.presence_online
             else android.R.drawable.presence_offline
             connectionIndicator.setImageResource(res)
+        }
+
+        viewModel.typing.observe(this) { typing ->
+            typingIndicator.visibility = if (typing) View.VISIBLE else View.GONE
+        }
+
+        viewModel.speaking.observe(this) { speaking ->
+            speakingIndicator.visibility = if (speaking) View.VISIBLE else View.GONE
         }
 
         sendButton.setOnClickListener {

--- a/clients/KurisuAssistant/app/src/main/res/layout/activity_main.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/activity_main.xml
@@ -73,27 +73,6 @@
             android:contentDescription="Record voice"/>
     </LinearLayout>
 
-    <TextView
-        android:id="@+id/speakingIndicator"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/speaking_indicator"
-        android:textColor="@color/primaryBlue"
-        android:visibility="gone"
-        app:layout_constraintBottom_toTopOf="@id/recordIndicator"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
-
-    <TextView
-        android:id="@+id/typingIndicator"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/typing_indicator"
-        android:textColor="@color/primaryBlue"
-        android:visibility="gone"
-        app:layout_constraintBottom_toTopOf="@id/speakingIndicator"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
 
     <TextView
         android:id="@+id/recordIndicator"

--- a/clients/KurisuAssistant/app/src/main/res/layout/activity_main.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/activity_main.xml
@@ -74,6 +74,28 @@
     </LinearLayout>
 
     <TextView
+        android:id="@+id/speakingIndicator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/speaking_indicator"
+        android:textColor="@color/primaryBlue"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@id/recordIndicator"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <TextView
+        android:id="@+id/typingIndicator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/typing_indicator"
+        android:textColor="@color/primaryBlue"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@id/speakingIndicator"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <TextView
         android:id="@+id/recordIndicator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/clients/KurisuAssistant/app/src/main/res/values/strings.xml
+++ b/clients/KurisuAssistant/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">KurisuAssistant</string>
+    <string name="typing_indicator">Generating text…</string>
+    <string name="speaking_indicator">Generating speech…</string>
 </resources>

--- a/clients/KurisuAssistant/app/src/main/res/values/strings.xml
+++ b/clients/KurisuAssistant/app/src/main/res/values/strings.xml
@@ -1,5 +1,3 @@
 <resources>
     <string name="app_name">KurisuAssistant</string>
-    <string name="typing_indicator">Generating text…</string>
-    <string name="speaking_indicator">Generating speech…</string>
 </resources>


### PR DESCRIPTION
## Summary
- add UI elements to show when the agent is speaking or typing
- expose typing/speaking state from Agent through repository and view model
- update main activity to observe indicators
- add new string resources

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7f86ed688321b344d61b53aff679