### PR TITLE
Fix chat bubble layout

### DIFF
--- a/clients/KurisuAssistant/app/src/main/res/layout/item_assistant_message.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/item_assistant_message.xml
@@ -16,9 +16,8 @@
 
     <TextView
         android:id="@+id/message_text"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
         android:background="@drawable/bg_assistant_message"
         android:padding="8dp"
         android:textColor="@android:color/black"

--- a/clients/KurisuAssistant/app/src/main/res/layout/item_user_message.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/item_user_message.xml
@@ -8,9 +8,8 @@
 
     <TextView
         android:id="@+id/message_text"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
         android:background="@drawable/bg_user_message"
         android:padding="8dp"
         android:textColor="@android:color/white"


### PR DESCRIPTION
## Summary
- adjust TextView width for assistant/user chat bubbles so text wraps properly

## Testing
- `./gradlew test` *(fails: permission denied / network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684de7df5cec832191034f906e99d420