### PR TITLE
Enable markdown rendering in Android client

### DIFF
--- a/clients/KurisuAssistant/app/build.gradle.kts
+++ b/clients/KurisuAssistant/app/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation(libs.androidx.recyclerview)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.ucrop)
+    implementation(libs.markwon)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatAdapter.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatAdapter.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
+import io.noties.markwon.Markwon
 import com.kurisuassistant.android.model.ChatMessage
 
 /**
@@ -26,6 +27,7 @@ class ChatAdapter(
 
     private var responding = false
     private var ellipsis = ""
+    private val markwon = Markwon.create(context)
     private val handler = Handler(Looper.getMainLooper())
     private val animateRunnable = object : Runnable {
         override fun run() {
@@ -76,7 +78,7 @@ class ChatAdapter(
         val msg = messages[position]
         when (holder) {
             is UserHolder -> {
-                holder.text.text = msg.text
+                markwon.setMarkdown(holder.text, msg.text)
                 val uri = AvatarManager.getUserAvatarUri()
                 if (uri != null) holder.avatar.setImageURI(uri)
                 else holder.avatar.setImageResource(R.drawable.avatar_user)
@@ -86,7 +88,7 @@ class ChatAdapter(
                 if (responding && position == messages.lastIndex) {
                     text += ellipsis
                 }
-                holder.text.text = text
+                markwon.setMarkdown(holder.text, text)
                 val uri = AvatarManager.getAgentAvatarUri()
                 if (uri != null) holder.avatar.setImageURI(uri)
                 else holder.avatar.setImageResource(R.drawable.avatar_assistant)

--- a/clients/KurisuAssistant/app/src/main/res/layout/item_assistant_message.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/item_assistant_message.xml
@@ -24,5 +24,6 @@
         android:textSize="16sp"
         android:scrollHorizontally="false"
         android:breakStrategy="simple"
+        android:autoLink="web"
         android:maxWidth="@dimen/message_max_width" />
 </LinearLayout>

--- a/clients/KurisuAssistant/app/src/main/res/layout/item_user_message.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/item_user_message.xml
@@ -16,6 +16,7 @@
         android:textSize="16sp"
         android:scrollHorizontally="false"
         android:breakStrategy="simple"
+        android:autoLink="web"
         android:maxWidth="@dimen/message_max_width" />
 
     <ImageView

--- a/clients/KurisuAssistant/gradle/libs.versions.toml
+++ b/clients/KurisuAssistant/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ media3CommonKtx = "1.7.1"
 recyclerview = "1.3.2"
 lifecycle = "2.8.1"
 ucrop = "2.2.8"
+markwon = "4.6.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -27,6 +28,7 @@ androidx-media3-common-ktx = { group = "androidx.media3", name = "media3-common-
 androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "recyclerview" }
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 ucrop = { group = "com.github.yalantis", name = "ucrop", version.ref = "ucrop" }
+markwon = { group = "io.noties.markwon", name = "core", version.ref = "markwon" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- support markdown messages on Android using the Markwon library
- auto-link URLs in Android chat message layouts
- address feedback by cleaning up imports and removing README change

## Testing
- `pytest`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685856c80c4c832180543ad6e375d531