### PR TITLE
Show newest conversations first

### DIFF
--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatAdapter.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatAdapter.kt
@@ -17,7 +17,7 @@ import com.kurisuassistant.android.model.ChatMessage
  */
 class ChatAdapter(
     private val context: Context,
-    private var messages: List<ChatMessage>
+    private var messages: List<ChatMessage>,
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     companion object {
@@ -79,6 +79,7 @@ class ChatAdapter(
         when (holder) {
             is UserHolder -> {
                 markwon.setMarkdown(holder.text, msg.text)
+                holder.time.text = msg.createdAt ?: ""
                 val uri = AvatarManager.getUserAvatarUri()
                 if (uri != null) holder.avatar.setImageURI(uri)
                 else holder.avatar.setImageResource(R.drawable.avatar_user)
@@ -89,6 +90,7 @@ class ChatAdapter(
                     text += ellipsis
                 }
                 markwon.setMarkdown(holder.text, text)
+                holder.time.text = msg.createdAt ?: ""
                 val uri = AvatarManager.getAgentAvatarUri()
                 if (uri != null) holder.avatar.setImageURI(uri)
                 else holder.avatar.setImageResource(R.drawable.avatar_assistant)
@@ -100,11 +102,13 @@ class ChatAdapter(
 
     class UserHolder(view: View) : RecyclerView.ViewHolder(view) {
         val text: TextView = view.findViewById(R.id.message_text)
+        val time: TextView = view.findViewById(R.id.message_time)
         val avatar: ImageView = view.findViewById(R.id.avatar)
     }
 
     class AssistantHolder(view: View) : RecyclerView.ViewHolder(view) {
         val text: TextView = view.findViewById(R.id.message_text)
+        val time: TextView = view.findViewById(R.id.message_time)
         val avatar: ImageView = view.findViewById(R.id.avatar)
     }
 }

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatAdapter.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatAdapter.kt
@@ -80,6 +80,11 @@ class ChatAdapter(
             is UserHolder -> {
                 markwon.setMarkdown(holder.text, msg.text)
                 holder.time.text = msg.createdAt ?: ""
+                holder.time.visibility = View.GONE
+                holder.text.setOnClickListener {
+                    holder.time.visibility =
+                        if (holder.time.visibility == View.VISIBLE) View.GONE else View.VISIBLE
+                }
                 val uri = AvatarManager.getUserAvatarUri()
                 if (uri != null) holder.avatar.setImageURI(uri)
                 else holder.avatar.setImageResource(R.drawable.avatar_user)
@@ -91,6 +96,11 @@ class ChatAdapter(
                 }
                 markwon.setMarkdown(holder.text, text)
                 holder.time.text = msg.createdAt ?: ""
+                holder.time.visibility = View.GONE
+                holder.text.setOnClickListener {
+                    holder.time.visibility =
+                        if (holder.time.visibility == View.VISIBLE) View.GONE else View.VISIBLE
+                }
                 val uri = AvatarManager.getAgentAvatarUri()
                 if (uri != null) holder.avatar.setImageURI(uri)
                 else holder.avatar.setImageResource(R.drawable.avatar_assistant)

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatHistory.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatHistory.kt
@@ -48,9 +48,14 @@ object ChatHistory {
         prefs.edit().putString(KEY, arr.toString()).apply()
     }
 
-    fun conversationTitles(): List<String> = conversations.mapIndexed { index, convo ->
-        convo.firstOrNull { it.isUser }?.text?.take(30) ?: "Conversation ${index + 1}"
-    }
+    fun conversationTitles(): List<String> = conversations
+        .asReversed()
+        .mapIndexed { index, convo ->
+            convo.firstOrNull { it.isUser }?.text?.take(30)
+                ?: "Conversation ${conversations.lastIndex - index + 1}"
+        }
+
+    fun indexFromNewest(displayIndex: Int): Int = conversations.lastIndex - displayIndex
 
     fun get(index: Int): MutableList<ChatMessage> = conversations[index]
 

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatHistory.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatHistory.kt
@@ -19,6 +19,7 @@ object ChatHistory {
 
     private lateinit var prefs: SharedPreferences
     private val conversations = mutableListOf<MutableList<ChatMessage>>()
+    private val titles = mutableListOf<String>()
 
     fun init(context: Context) {
         prefs = context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
@@ -26,15 +27,45 @@ object ChatHistory {
         val json = prefs.getString(KEY, "[]")
         val arr = JSONArray(json)
         for (i in 0 until arr.length()) {
-            val convoArr = arr.getJSONArray(i)
-            val convo = mutableListOf<ChatMessage>()
-            for (j in 0 until convoArr.length()) {
-                val obj = convoArr.getJSONObject(j)
-                convo.add(ChatMessage(obj.getString("text"), obj.getBoolean("isUser")))
+            val element = arr.get(i)
+            if (element is JSONArray) {
+                val convoArr = element
+                val convo = mutableListOf<ChatMessage>()
+                for (j in 0 until convoArr.length()) {
+                    val obj = convoArr.getJSONObject(j)
+                    convo.add(
+                        ChatMessage(
+                            obj.getString("text"),
+                            obj.getBoolean("isUser"),
+                            obj.optString("created_at", null)
+                        )
+                    )
+                }
+                conversations.add(convo)
+                titles.add(convo.firstOrNull { it.isUser }?.text?.take(30) ?: "Conversation ${i + 1}")
+            } else {
+                val obj = arr.getJSONObject(i)
+                val title = obj.optString("title")
+                val convoArr = obj.getJSONArray("messages")
+                val convo = mutableListOf<ChatMessage>()
+                for (j in 0 until convoArr.length()) {
+                    val msg = convoArr.getJSONObject(j)
+                    convo.add(
+                        ChatMessage(
+                            msg.optString("text", msg.optString("content")),
+                            msg.optBoolean("isUser", msg.optString("role") == "user"),
+                            msg.optString("created_at", null)
+                        )
+                    )
+                }
+                conversations.add(convo)
+                titles.add(title.ifEmpty { convo.firstOrNull { it.isUser }?.text?.take(30) ?: "Conversation ${i + 1}" })
             }
-            conversations.add(convo)
         }
-        if (conversations.isEmpty()) conversations.add(mutableListOf())
+        if (conversations.isEmpty()) {
+            conversations.add(mutableListOf())
+            titles.add("Conversation 1")
+        }
     }
 
     suspend fun fetchFromServer() = withContext(Dispatchers.IO) {
@@ -46,21 +77,29 @@ object ChatHistory {
                 if (!resp.isSuccessful) return@withContext
                 val arr = JSONArray(resp.body!!.string())
                 conversations.clear()
+                titles.clear()
                 for (i in 0 until arr.length()) {
-                    val convoArr = arr.getJSONObject(i).getJSONArray("messages")
+                    val convoObj = arr.getJSONObject(i)
+                    val title = convoObj.optString("title")
+                    val convoArr = convoObj.getJSONArray("messages")
                     val convo = mutableListOf<ChatMessage>()
                     for (j in 0 until convoArr.length()) {
                         val obj = convoArr.getJSONObject(j)
                         val role = obj.optString("role")
                         val content = obj.optString("content")
+                        val created = obj.optString("created_at", null)
                         when (role) {
-                            "user" -> convo.add(ChatMessage(content, true))
-                            "assistant" -> convo.add(ChatMessage(content, false))
+                            "user" -> convo.add(ChatMessage(content, true, created))
+                            "assistant" -> convo.add(ChatMessage(content, false, created))
                         }
                     }
                     conversations.add(convo)
+                    titles.add(title)
                 }
-                if (conversations.isEmpty()) conversations.add(mutableListOf())
+                if (conversations.isEmpty()) {
+                    conversations.add(mutableListOf())
+                    titles.add("Conversation 1")
+                }
                 persist()
             }
         } catch (_: Exception) {
@@ -68,26 +107,36 @@ object ChatHistory {
         }
     }
 
+    suspend fun fetchConversation(index: Int): MutableList<ChatMessage>? {
+        fetchFromServer()
+        return conversations.getOrNull(index)
+    }
+
     private fun persist() {
         val arr = JSONArray()
-        for (convo in conversations) {
+        for (i in conversations.indices) {
+            val convo = conversations[i]
+            val convoObj = JSONObject()
+            convoObj.put("title", titles.getOrElse(i) { "" })
             val convoArr = JSONArray()
             for (msg in convo) {
                 val obj = JSONObject()
                 obj.put("text", msg.text)
                 obj.put("isUser", msg.isUser)
+                if (msg.createdAt != null) obj.put("created_at", msg.createdAt)
                 convoArr.put(obj)
             }
-            arr.put(convoArr)
+            convoObj.put("messages", convoArr)
+            arr.put(convoObj)
         }
         prefs.edit().putString(KEY, arr.toString()).apply()
     }
 
-    fun conversationTitles(): List<String> = conversations
+    fun conversationTitles(): List<String> = titles
         .asReversed()
-        .mapIndexed { index, convo ->
-            convo.firstOrNull { it.isUser }?.text?.take(30)
-                ?: "Conversation ${conversations.lastIndex - index + 1}"
+        .mapIndexed { index, title ->
+            if (title.isNotEmpty()) title
+            else "Conversation ${conversations.lastIndex - index + 1}"
         }
 
     fun indexFromNewest(displayIndex: Int): Int = conversations.lastIndex - displayIndex
@@ -96,11 +145,15 @@ object ChatHistory {
 
     fun update(index: Int, messages: MutableList<ChatMessage>) {
         conversations[index] = messages
+        if (titles[index].isEmpty()) {
+            titles[index] = messages.firstOrNull { it.isUser }?.text?.take(30) ?: titles[index]
+        }
         persist()
     }
 
     fun add(): Int {
         conversations.add(mutableListOf())
+        titles.add("")
         persist()
         return conversations.lastIndex
     }

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatRepository.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatRepository.kt
@@ -53,8 +53,13 @@ object ChatRepository {
     fun init(context: Context? = null) {
         agent
         context?.let { ChatHistory.init(it) }
-        if (context != null && ChatHistory.size > 0) {
-            _messages.value = ChatHistory.get(currentIndex)
+        if (context != null) {
+            scope.launch {
+                ChatHistory.fetchFromServer()
+                if (ChatHistory.size > 0) {
+                    _messages.postValue(ChatHistory.get(currentIndex))
+                }
+            }
         }
     }
 

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatRepository.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatRepository.kt
@@ -11,6 +11,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import java.time.Instant
 
 /**
  * Singleton repository that manages chat messages and communicates with [Agent].
@@ -19,6 +22,7 @@ object ChatRepository {
     private val _messages = MutableLiveData<MutableList<ChatMessage>>(mutableListOf())
     val messages: LiveData<MutableList<ChatMessage>> = _messages
     private var currentIndex = 0
+    private var pollJob: Job? = null
 
     private val player: AudioTrack by lazy {
         AudioTrack.Builder()
@@ -58,6 +62,7 @@ object ChatRepository {
                 ChatHistory.fetchFromServer()
                 if (ChatHistory.size > 0) {
                     _messages.postValue(ChatHistory.get(currentIndex))
+                    startPolling(currentIndex)
                 }
             }
         }
@@ -68,19 +73,19 @@ object ChatRepository {
      */
     fun sendMessage(text: String) {
         val list = _messages.value ?: mutableListOf()
-        list.add(ChatMessage(text, true))
+        list.add(ChatMessage(text, true, Instant.now().toString()))
         _messages.value = list
         ChatHistory.update(currentIndex, list)
 
         scope.launch {
             val channel: Channel<String> = agent.chat(text)
-            val assistant = ChatMessage("", false)
+            val assistant = ChatMessage("", false, Instant.now().toString())
             list.add(assistant)
             val idx = list.lastIndex
             _messages.postValue(ArrayList(list))
             ChatHistory.update(currentIndex, list)
             for (chunk in channel) {
-                list[idx] = ChatMessage(list[idx].text + chunk, false)
+                list[idx] = ChatMessage(list[idx].text + chunk, false, assistant.createdAt)
                 _messages.postValue(ArrayList(list))
                 ChatHistory.update(currentIndex, list)
             }
@@ -93,8 +98,8 @@ object ChatRepository {
      */
     fun addVoiceUserMessage(text: String): Int {
         val list = _messages.value ?: mutableListOf()
-        list.add(ChatMessage(text, true))
-        val assistant = ChatMessage("", false)
+        list.add(ChatMessage(text, true, Instant.now().toString()))
+        val assistant = ChatMessage("", false, Instant.now().toString())
         list.add(assistant)
         val idx = list.lastIndex
         _messages.postValue(ArrayList(list))
@@ -110,7 +115,7 @@ object ChatRepository {
         val list = _messages.value ?: return
         if (index >= list.size) return
         val current = list[index]
-        list[index] = ChatMessage(current.text + chunk, false)
+        list[index] = ChatMessage(current.text + chunk, false, current.createdAt)
         _messages.postValue(ArrayList(list))
         ChatHistory.update(currentIndex, list)
     }
@@ -118,6 +123,7 @@ object ChatRepository {
     fun startNewConversation() {
         currentIndex = ChatHistory.add()
         _messages.postValue(mutableListOf())
+        startPolling(currentIndex)
     }
 
     fun switchConversation(index: Int) {
@@ -125,5 +131,18 @@ object ChatRepository {
         ChatHistory.update(currentIndex, _messages.value ?: mutableListOf())
         currentIndex = index
         _messages.postValue(ArrayList(ChatHistory.get(index)))
+        startPolling(currentIndex)
+    }
+
+    private fun startPolling(index: Int) {
+        pollJob?.cancel()
+        pollJob = scope.launch {
+            while (currentIndex == index) {
+                ChatHistory.fetchConversation(index)?.let {
+                    _messages.postValue(ArrayList(it))
+                }
+                delay(1000)
+            }
+        }
     }
 }

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/MainActivity.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/MainActivity.kt
@@ -63,7 +63,8 @@ class MainActivity : AppCompatActivity() {
         drawerAdapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, ChatHistory.conversationTitles())
         convList.adapter = drawerAdapter
         convList.setOnItemClickListener { _, _, position, _ ->
-            ChatRepository.switchConversation(position)
+            val actualIndex = ChatHistory.indexFromNewest(position)
+            ChatRepository.switchConversation(actualIndex)
             drawerLayout.closeDrawers()
             refreshDrawer()
         }

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/model/ChatMessage.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/model/ChatMessage.kt
@@ -5,6 +5,7 @@ package com.kurisuassistant.android.model
  */
 data class ChatMessage(
     val text: String,
-    val isUser: Boolean
+    val isUser: Boolean,
+    val createdAt: String? = null,
 )
 

--- a/clients/KurisuAssistant/app/src/main/res/layout/item_assistant_message.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/item_assistant_message.xml
@@ -35,6 +35,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textColor="@android:color/darker_gray"
-            android:textSize="10sp" />
+            android:textSize="10sp"
+            android:visibility="gone" />
     </LinearLayout>
 </LinearLayout>

--- a/clients/KurisuAssistant/app/src/main/res/layout/item_assistant_message.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/item_assistant_message.xml
@@ -14,16 +14,27 @@
         android:src="@drawable/avatar_assistant"
         android:contentDescription="Assistant avatar" />
 
-    <TextView
-        android:id="@+id/message_text"
+    <LinearLayout
+        android:orientation="vertical"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:background="@drawable/bg_assistant_message"
-        android:padding="8dp"
-        android:textColor="@android:color/black"
-        android:textSize="16sp"
-        android:scrollHorizontally="false"
-        android:breakStrategy="simple"
-        android:autoLink="web"
-        android:maxWidth="@dimen/message_max_width" />
+        android:layout_height="wrap_content">
+        <TextView
+            android:id="@+id/message_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_assistant_message"
+            android:padding="8dp"
+            android:textColor="@android:color/black"
+            android:textSize="16sp"
+            android:scrollHorizontally="false"
+            android:breakStrategy="simple"
+            android:autoLink="web"
+            android:maxWidth="@dimen/message_max_width" />
+        <TextView
+            android:id="@+id/message_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@android:color/darker_gray"
+            android:textSize="10sp" />
+    </LinearLayout>
 </LinearLayout>

--- a/clients/KurisuAssistant/app/src/main/res/layout/item_user_message.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/item_user_message.xml
@@ -6,18 +6,29 @@
     android:gravity="end"
     android:padding="8dp">
 
-    <TextView
-        android:id="@+id/message_text"
+    <LinearLayout
+        android:orientation="vertical"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:background="@drawable/bg_user_message"
-        android:padding="8dp"
-        android:textColor="@android:color/white"
-        android:textSize="16sp"
-        android:scrollHorizontally="false"
-        android:breakStrategy="simple"
-        android:autoLink="web"
-        android:maxWidth="@dimen/message_max_width" />
+        android:layout_height="wrap_content">
+        <TextView
+            android:id="@+id/message_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_user_message"
+            android:padding="8dp"
+            android:textColor="@android:color/white"
+            android:textSize="16sp"
+            android:scrollHorizontally="false"
+            android:breakStrategy="simple"
+            android:autoLink="web"
+            android:maxWidth="@dimen/message_max_width" />
+        <TextView
+            android:id="@+id/message_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@android:color/darker_gray"
+            android:textSize="10sp" />
+    </LinearLayout>
 
     <ImageView
         android:id="@+id/avatar"

--- a/clients/KurisuAssistant/app/src/main/res/layout/item_user_message.xml
+++ b/clients/KurisuAssistant/app/src/main/res/layout/item_user_message.xml
@@ -27,7 +27,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textColor="@android:color/darker_gray"
-            android:textSize="10sp" />
+            android:textSize="10sp"
+            android:visibility="gone" />
     </LinearLayout>
 
     <ImageView

--- a/core/db.py
+++ b/core/db.py
@@ -1,6 +1,7 @@
 import os
 import psycopg2
 import json
+import datetime
 from passlib.context import CryptContext
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -68,7 +69,12 @@ def add_message(
     row = cur.fetchone()
     if row:
         conv_id, messages = row
-        messages["messages"].append({"role": role, "content": content, "model": model})
+        messages["messages"].append({
+            "role": role,
+            "content": content,
+            "model": model,
+            "created_at": datetime.datetime.utcnow().isoformat(),
+        })
         cur.execute(
             "UPDATE conversations SET messages=%s WHERE id=%s",
             (json.dumps(messages), conv_id),
@@ -81,7 +87,14 @@ def add_message(
         ]
         new_messages = {
             "messages": formatted_prompts
-            + [{"role": role, "content": content, "model": model}]
+            + [
+                {
+                    "role": role,
+                    "content": content,
+                    "model": model,
+                    "created_at": datetime.datetime.utcnow().isoformat(),
+                }
+            ]
         }
         cur.execute(
             "INSERT INTO conversations (username, title, messages) VALUES (%s, %s, %s)",


### PR DESCRIPTION
## Summary
- list conversations in reverse order so the newest is first
- map drawer indices back to the stored order when switching conversations

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687480971b788321abdc5a68dbbffb06