### PR TITLE
Store entire LLM conversation

### DIFF
--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatAdapter.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatAdapter.kt
@@ -90,7 +90,7 @@ class ChatAdapter(
                 else holder.avatar.setImageResource(R.drawable.avatar_user)
             }
             is AssistantHolder -> {
-                var text = msg.text
+                var text = msg.displayText
                 if (responding && position == messages.lastIndex) {
                     text += ellipsis
                 }

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/RecordingService.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/RecordingService.kt
@@ -227,13 +227,7 @@ class RecordingService : Service() {
                         if (isInteracting)
                         {
                             Log.d(TAG, "User: $text")
-                            val idx = ChatRepository.addVoiceUserMessage(text)
-                            val chatStream = agent.chat(text)
-                            for (content in chatStream)
-                            {
-                                ChatRepository.appendAssistantChunk(content, idx)
-                                Log.d(TAG, "Assistant: $content")
-                            }
+                            ChatRepository.sendMessage(text)
                             // audio replies are fetched via REST and played automatically
                             lastInteractionTimeStamp = System.currentTimeMillis()
                         }

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/model/ChatMessage.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/model/ChatMessage.kt
@@ -5,7 +5,11 @@ package com.kurisuassistant.android.model
  */
 data class ChatMessage(
     val text: String,
-    val isUser: Boolean,
+    val role: String,
     val createdAt: String? = null,
-)
+    val toolCalls: String? = null,
+) {
+    val isUser: Boolean
+        get() = role == "user"
+}
 

--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/model/ChatMessage.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/model/ChatMessage.kt
@@ -3,6 +3,9 @@ package com.kurisuassistant.android.model
 /**
  * Represents a single chat message either from the user or the assistant.
  */
+import org.json.JSONArray
+import org.json.JSONObject
+
 data class ChatMessage(
     val text: String,
     val role: String,
@@ -11,5 +14,35 @@ data class ChatMessage(
 ) {
     val isUser: Boolean
         get() = role == "user"
+
+    val displayText: String
+        get() = if (!toolCalls.isNullOrEmpty()) {
+            val builder = StringBuilder()
+            if (text.isNotEmpty()) builder.append(text).append("\n")
+            builder.append(formatToolCalls())
+            builder.toString()
+        } else {
+            text
+        }
+
+    private fun formatToolCalls(): String = try {
+        val arr = JSONArray(toolCalls)
+        val calls = mutableListOf<String>()
+        for (i in 0 until arr.length()) {
+            val call = arr.getJSONObject(i)
+            val func = call.getJSONObject("function")
+            val name = func.optString("name")
+            var args = func.optString("arguments")
+            args = try {
+                JSONObject(args).toString(2)
+            } catch (_: Exception) {
+                args
+            }
+            calls.add("$name\n```\n$args\n```")
+        }
+        calls.joinToString("\n")
+    } catch (_: Exception) {
+        toolCalls ?: ""
+    }
 }
 

--- a/core/helpers/llm.py
+++ b/core/helpers/llm.py
@@ -31,51 +31,73 @@ class LLM:
         self.client.pull(model_name)
 
     async def __call__(self, payload):
+        """Send a chat request and yield streaming responses.
 
-        full_response = ""
-        response_buffer = ""
-        partial_response = ""
-        is_final = False
-        json_response = None
-        self.history.append({**payload['message'], 'model': None})
-        while not is_final:
-            is_final = True
+        The entire conversation, including intermediate tool calls and assistant
+        replies, is stored in ``self.history``.
+        """
+
+        self.history.append({**payload["message"], "model": None})
+
+        accumulated = ""
+        buffer = ""
+
+        while True:
             tools = await list_tools(self.mcp_client)
-            
             messages = self.system_prompts + self.history
-            stream = self.client.chat(model = payload['model'], messages=messages, stream = payload['stream'], tools=tools)
-            for chunk in stream:
-                json_response = chunk.dict()
-                print(json_response)
-                if chunk.message.tool_calls is not None:
-                    for tool_call in chunk.message.tool_calls:
-                        result = await call_tool(self.mcp_client, tool_call.function.name, tool_call.function.arguments)
-                        json_tool_response = {"text": result[0].text}
-                        self.history.append({
-                            "role": "user",
-                            "content": f"<tool_response> {json.dumps(json_tool_response)} </tool_response>",
-                            "model": None,
-                        })
-                        print(self.history[-1])
-                    is_final = False
-                
-                if is_final:
-                    full_response += chunk.message.content
-                    #full_response = re.sub(r'<think>.*?</think>', '', full_response, flags=re.DOTALL)
-                    partial_response += chunk.message.content
+            stream = self.client.chat(
+                model=payload["model"],
+                messages=messages,
+                stream=payload["stream"],
+                tools=tools,
+            )
 
-                    delimiter_idx = max([partial_response.rfind(delimiter) for delimiter in self.delimiters])
-                    if delimiter_idx != -1:
-                        response_buffer += partial_response[:delimiter_idx+1]
-                        partial_response = partial_response[delimiter_idx+1:]
-                    elif chunk['done']:
-                        response_buffer += partial_response
-                        partial_response = ""
-                    
-                    if (len(response_buffer) > 20 or chunk['done']):
-                        json_response['message']['content'] = response_buffer
-                        yield json_response
-                        response_buffer = ""
-                    
-        self.history.append({"role": "assistant", "content": full_response, "model": payload.get('model')})
-        print(self.history[-1])
+            made_tool_call = False
+            for chunk in stream:
+                data = chunk.dict()
+                msg = chunk.message
+
+                if msg.tool_calls:
+                    self.history.append(
+                        {"role": "assistant", "content": msg.content, "model": payload.get("model")}
+                    )
+                    for tool_call in msg.tool_calls:
+                        result = await call_tool(
+                            self.mcp_client,
+                            tool_call.function.name,
+                            tool_call.function.arguments,
+                        )
+                        tool_text = result[0].text
+                        self.history.append(
+                            {
+                                "role": "user",
+                                "content": f"<tool_response> {json.dumps({'text': tool_text})} </tool_response>",
+                                "model": None,
+                            }
+                        )
+                        yield {
+                            "message": {"role": "tool", "content": tool_text},
+                            "done": True,
+                        }
+                        print(self.history[-1])
+                    made_tool_call = True
+                    break
+
+                accumulated += msg.content
+                buffer += msg.content
+                if len(buffer) > 20 or data.get("done"):
+                    data["message"]["content"] = buffer
+                    yield data
+                    buffer = ""
+                if data.get("done"):
+                    self.history.append(
+                        {"role": "assistant", "content": accumulated, "model": payload.get("model")}
+                    )
+                    print(self.history[-1])
+                    return
+
+            if not made_tool_call:
+                break
+            accumulated = ""
+            buffer = ""
+

--- a/core/llm_hub.py
+++ b/core/llm_hub.py
@@ -121,7 +121,13 @@ async def chat(request: Request, token: str = Depends(oauth2_scheme)):
             yield json.dumps(chunk) + "\n"
 
             if msg.get("tool_calls"):
-                add_message(username, "assistant", full_response, payload.get("model"))
+                add_message(
+                    username,
+                    "assistant",
+                    full_response,
+                    payload.get("model"),
+                    tool_calls=msg.get("tool_calls"),
+                )
                 full_response = ""
                 continue
 


### PR DESCRIPTION
## Summary
- emit tool call results from the `LLM` helper
- store tool responses and every assistant message in the database
- clean up the LLM generator and keep intermediate assistant replies in history

## Testing
- `python -m py_compile core/helpers/llm.py core/llm_hub.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68748ef41cec8321acc2e54e7720fb29