### PR TITLE
Update Android voice conversation logic

### DIFF
--- a/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatRepository.kt
+++ b/clients/KurisuAssistant/app/src/main/java/com/kurisuassistant/android/ChatRepository.kt
@@ -48,8 +48,15 @@ object ChatRepository {
     val speaking: LiveData<Boolean>
         get() = agent.speaking
 
+    private val _conversationActive = MutableLiveData(false)
+    val conversationActive: LiveData<Boolean> = _conversationActive
+
     fun init() {
         agent
+    }
+
+    fun setConversationActive(active: Boolean) {
+        _conversationActive.postValue(active)
     }
 
     /**


### PR DESCRIPTION
## Summary
- start conversation only after hearing the "Kurisu" keyword
- end conversation after 10 seconds of inactivity
- expose conversation mode state via `ChatRepository`

## Testing
- `python -m unittest discover -v`
- `./gradlew test --no-daemon --console=plain` *(fails: Android SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874a4fc82f88321b0134393ca7d4369