### PR TITLE
Update client link to KurisuAssistant-Client-Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ python -m scripts.migrate # Run database migrations
 
 ## Client
 
-See [KurisuAssistant-Client-Windows](https://github.com/Khoality-dev/KurisuAssistant-Client-Windows) for the Electron + React desktop client.
+See [KurisuAssistant-Client-Desktop](https://github.com/Khoality-dev/KurisuAssistant-Client-Desktop) for the cross-platform (Windows + Linux) Electron + React desktop client.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- Update README link from KurisuAssistant-Client-Windows to KurisuAssistant-Client-Desktop (client now targets Windows + Linux)

## Test plan
- [ ] After merge, the link will start redirecting until the GitHub repo rename is also done; the new URL becomes canonical once renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)